### PR TITLE
avoid a rustc bug

### DIFF
--- a/parse-hyperlinks/src/renderer.rs
+++ b/parse-hyperlinks/src/renderer.rs
@@ -513,7 +513,7 @@ pub fn text_rawlinks2html_writer<'a, S: 'a + AsRef<str>, W: Write>(
 ) -> Result<(), io::Error> {
     let input = input.as_ref();
 
-    let verb_renderer = |verb: Cow<'a, str>| verb;
+    let verb_renderer = |verb| verb;
 
     let link_renderer = |(consumed, (_, dest, title)): (Cow<str>, (_, String, String))| {
         let mut s = String::new();


### PR DESCRIPTION
Hi,

https://github.com/rust-lang/rust/pull/98835 fixes a rustc bug that makes it incorrectly accepts the following code:
```rust
fn test<'a: 'a>() { // 'a is longer than the entire function body
    let f = |_: &'a str| {}; // expects an argument that lives as long as 'a
    f(&String::new()); // the passed reference is shorter that `'a`
}
```

The crater run found that `parse-hyperlinks` relies on this bug. I'm not sure when this change reaches stable, if ever, but it's better to not rely on such a bug. This PR tries to fix this.



If you have an opinion on this change, please let me know here or  by commenting on the PR.

You can install and test the toolchain locally by running the command: `rustup-toolchain-install-master cb1f7c96119295882e08b09b4bd01051669c071b`